### PR TITLE
Install secrets for License-Vetting GitHub workflow on eclipse.jdt.ls

### DIFF
--- a/otterdog/eclipse-jdtls.jsonnet
+++ b/otterdog/eclipse-jdtls.jsonnet
@@ -26,6 +26,15 @@ orgs.newOrg('eclipse-jdtls') {
       ],
     },
   ],
+  secrets+: [
+    orgs.newOrgSecret('ECLIPSE_GITLAB_API_TOKEN') {
+      selected_repositories+: [
+        "eclipse.jdt.ls"
+      ],
+      value: "pass:bots/eclipse.jdt.ls/gitlab.eclipse.org/api-token",
+      visibility: "selected",
+    },
+  ],
   _repositories+:: [
     orgs.newRepo('eclipse-jdt-core-incubator') {
       allow_merge_commit: true,


### PR DESCRIPTION
EF issue: https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/3969