### PR TITLE
Set "dom-with-javac" as default branch in eclipse-jdt-core-incubator

### DIFF
--- a/otterdog/eclipse-jdtls.jsonnet
+++ b/otterdog/eclipse-jdtls.jsonnet
@@ -31,7 +31,7 @@ orgs.newOrg('eclipse-jdtls') {
   ],
   _repositories+:: [
     orgs.newRepo('eclipse-jdt-core-incubator') {
-      default_branch: "master",
+      default_branch: "dom-with-javac",
       delete_branch_on_merge: false,
       dependabot_alerts_enabled: false,
       has_discussions: true,


### PR DESCRIPTION
It's the currently active branch. This change will allow Github to index it so we can perform searches through the web ui.