### PR TITLE
Rename default branch to 'main'.

### DIFF
--- a/otterdog/eclipse-jdtls.jsonnet
+++ b/otterdog/eclipse-jdtls.jsonnet
@@ -40,7 +40,6 @@ orgs.newOrg('eclipse.jdt.ls', 'eclipse-jdtls') {
     },
     orgs.newRepo('eclipse.jdt.ls') {
       allow_update_branch: false,
-      default_branch: "master",
       delete_branch_on_merge: false,
       dependabot_security_updates_enabled: true,
       description: "Java language server",
@@ -97,7 +96,7 @@ orgs.newOrg('eclipse.jdt.ls', 'eclipse-jdtls') {
         },
       ],
       branch_protection_rules: [
-        orgs.newBranchProtectionRule('master') {
+        orgs.newBranchProtectionRule('main') {
           required_approving_review_count: null,
           requires_pull_request: false,
           requires_status_checks: false,


### PR DESCRIPTION
@netomi let me know if this is what's needed to rename the default branch for https://github.com/eclipse-jdtls/eclipse.jdt.ls . Based on recommendations from https://gitlab.eclipse.org/eclipsefdn/emo-team/emo/-/issues/719#note_3458915 .